### PR TITLE
🐛 fixed email link in i18n interpolation

### DIFF
--- a/components/section/faq.vue
+++ b/components/section/faq.vue
@@ -2,7 +2,7 @@
   <section aria-labelledby="faq-heading" class="bg-white">
     <content-wrapper>
       <h2 class="text-3xl font-extrabold text-gray-900">{{ $t('title') }}</h2>
-      <i18n path="description" tag="h2" class="mt-5 text-xl text-gray-500">
+      <i18n path="description" tag="h2" class="mt-5 text-xl text-gray-500" v-slot:link>
         <a :href="$t('mailto')" class="external-link font-medium text-linked-700 hover:text-linked-500">{{ $t('email') }}</a>
       </i18n>
       <dl class="mt-12 space-y-10 md:space-y-0 md:grid md:grid-cols-2 md:gap-x-8 md:gap-y-12 lg:grid-cols-3">
@@ -45,7 +45,7 @@ export default {
   },
   "de": {
     "title": "FAQ",
-    "description": "Fragen. Häufig gestellte Fragen. Und unsere Antworten. So funktionieren die FAQs. Wenn Du nicht finden konntest, wonach Du gesucht hast, kannst Du deine Anfrage jederzeit {0} an mich senden.",
+    "description": "Fragen. Häufig gestellte Fragen. Und unsere Antworten. So funktionieren die FAQs. Wenn Du nicht finden konntest, wonach Du gesucht hast, kannst Du deine Anfrage jederzeit {link} an mich senden.",
     "email": "per E-Mail",
     "mailto": "mailto:support@uselinked.com?subject=Frage bzgl. linked&body=Liebes linked Team, könnt ihr mir folgende Frage beantworten....",
     "questions": {


### PR DESCRIPTION
Hi,

The email link at the FAQ section was not working properly at [uselinked.com](https://uselinked.com). Attaching a screenshot for reference. It says `you can always with your enquiry` instead of `you can always send me an email with your enquiry`.

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/40194401/167240981-636efbae-60f1-4491-833f-8811ee11ec2b.png">

This PR fixes this issue for both the English and German versions. This is how the fixed version looks.

<img width="1338" alt="image" src="https://user-images.githubusercontent.com/40194401/167241085-95d2d699-f496-4f4e-904b-2436b5e4b841.png">

Please take a look and provide your feedback!

Thanks